### PR TITLE
changes snap button, query buttons and dowload button

### DIFF
--- a/R/mod_env_var_analysis.R
+++ b/R/mod_env_var_analysis.R
@@ -1,7 +1,8 @@
 # This module allows selecting environmental variables
 # and querying the GeoFRESH database
 
-
+library(bslib)
+library(bsicons)
 # Module UI function
 envVarAnalysisUI <- function(id) {
   ns <- NS(id)
@@ -73,12 +74,18 @@ envVarAnalysisUI <- function(id) {
             column(
               2,
               # button for starting query
-              shinyjs::disabled(actionButton(
-                ns("env_button_local"),
-                "Start query",
-                icon = icon("play"),
-                class = "btn-primary"
-              )),
+              shinyjs::disabled(
+                actionButton(ns("env_button_local"),
+                             "Start query",
+                             icon = icon("play"),
+                             class = "btn-primary"
+                             )
+                ),
+                bsTooltip(ns("env_button_local"),
+                        "Please, snap points first",
+                        "right",
+                        options = list(container = "body")
+                        ),
               shinyjs::hidden(p(id = ns("text1"), "Processing..."))
             ),
             column(
@@ -146,6 +153,11 @@ envVarAnalysisUI <- function(id) {
                 icon = icon("play"),
                 class = "btn-primary"
               )),
+              bsTooltip(ns("env_button_upstr"),
+                        "Please, snap points first",
+                        "right",
+                        options = list(container = "body")
+              ),
               shinyjs::hidden(p(id = ns("text2"), "Processing..."))
             ),
             column(
@@ -359,12 +371,17 @@ envVarAnalysisServer <- function(id, point) {
 
 
       # activate query buttons after snapped coordinate data frame is created
+      # and remove tooltips
       observeEvent(datasets$snapped, {
         toggleState("env_button_local")
+        removeTooltip(session, ns("env_button_local"))
       })
       observeEvent(datasets$snapped, {
         toggleState("env_button_upstr")
+        removeTooltip(session, ns("env_button_upstr"))
       })
+
+
 
       # check if checked box exist when clicking query button for local
       # sub-catchment

--- a/R/mod_snap_points.R
+++ b/R/mod_snap_points.R
@@ -16,12 +16,17 @@ snapPointUI <- function(id, label = "Snap points") {
     ))
     ,
     br(),
-    # progressBar(
-    #   id = ns("progress_snap"),
-    #   value = 0,
-    #   title = " ",
-    #   display_pct = TRUE
-    # ),
+    progressBar(
+      id = ns("progress_snap"),
+      value = 0,
+      title = " ",
+      display_pct = TRUE
+    ),
+    bsTooltip(ns("snap_button"),
+              "Please, upload point data first",
+              "right",
+              options = list(container = "body")
+    ),
     shinyjs::hidden(p(id = ns("text1"), "Processing..."))
   )
 }

--- a/R/mod_snap_points.R
+++ b/R/mod_snap_points.R
@@ -9,19 +9,19 @@ snapPointUI <- function(id, label = "Snap points") {
     tags$b("Snapping method: sub-catchment (default)"),
     p("Points will be snapped to the nearest location on the
               river segment of the sub-catchment the point falls in."),
-    # Inactive action button. It is activated after data point is uploaded.
+    # Inactive action button. It is activated after point data is uploaded.
     # Point snapping starts after clicking
     shinyjs::disabled(actionButton(ns("snap_button"),
-                 label = "Snap points",
-                 icon = icon("arrow-right"),
-                 class = "btn-primary"
+      label = "Snap points",
+      icon = icon("arrow-right"),
+      class = "btn-primary"
     )),
     # Tooltip to indicate point data must be uploaded before snapping.
     # It is hidden after point data is uploaded
     bsTooltip(ns("snap_button"),
-              "Please, upload your data first or load test data",
-              "right",
-              options = list(container = "body")
+      "Please, upload your data first or load test data",
+      "right",
+      options = list(container = "body")
     ),
     br(),
     # Progress bar, indicates the progress of snapping process
@@ -64,15 +64,11 @@ snapPointServer <- function(id, input_point_table) {
         removeTooltip(session, ns("snap_button"))
       })
 
-      # reactive value object. Its value change after snapping is completed
-      snappinready <- reactiveValues(ok = FALSE)
-
       # reactive value object to save results after snapping
-      snapped_data <- reactiveValues(data = NULL)
+      snapped_data <- reactiveVal()
 
       # If click snap button, snap points, otherwise do nothing
-        observeEvent(input$snap_button, {
-
+      observeEvent(input$snap_button, {
         # stop if a table with input points does not exist
         req(input_point_table())
 
@@ -80,7 +76,6 @@ snapPointServer <- function(id, input_point_table) {
         # clicking during snapping
         shinyjs::disable("snap_button")
         shinyjs::show("text1")
-        snappinready$ok <- FALSE
 
         # set user input points table name
         points_table <- Id(schema = "shiny_user", table = input_point_table())
@@ -184,9 +179,8 @@ snapPointServer <- function(id, input_point_table) {
           FROM ?point_table",
           point_table = dbQuoteIdentifier(pool, points_table)
         )
-        # return result dataframe
-        snapped_data$data <- dbGetQuery(pool, sql)
-        snappinready$ok <- TRUE
+        # set snapped_data reactive value to resulting data frame
+        snapped_data(dbGetQuery(pool, sql))
 
         # hide processing text
         shinyjs::hide("text1")
@@ -196,12 +190,13 @@ snapPointServer <- function(id, input_point_table) {
 
         # show tooltip again
         addTooltip(session,
-                   ns("snap_button"),
-                   "Please, upload point data first",
-                   placement = "right")
+          ns("snap_button"),
+          "Please, upload point data first",
+          placement = "right"
+        )
 
         # enable snap button
-        #shinyjs::enable("snap_button")
+        # shinyjs::enable("snap_button")
       })
 
       # Option 2: snap point to nearest stream segment
@@ -226,8 +221,8 @@ snapPointServer <- function(id, input_point_table) {
 
       # query result dataframe
 
-      # resturn results of one of the snapping method after snapping
-      coordinates_snap <- eventReactive(snappinready$ok, snapped_data$data)
+      # return results of one of the snapping method after snapping
+      return(snapped_data)
     }
   )
 }

--- a/R/mod_snap_points.R
+++ b/R/mod_snap_points.R
@@ -48,19 +48,19 @@ snapPointServer <- function(id, input_point_table) {
       # progress bar
       steps <- 6
 
-      custom_updateProgressBar <- function(perc) {
+      custom_updateProgressBar <- function(perc, sleep = 0.1) {
         updateProgressBar(
           session = session,
           id = ns("progress_snap"),
           value = perc
         )
-        Sys.sleep(0.1)
+        Sys.sleep(sleep)
       }
 
       # activate snap button and hide tooltip after a table with the user's
       # points is loaded
       observeEvent(input_point_table(), {
-        toggleState("snap_button")
+        shinyjs::enable("snap_button")
         removeTooltip(session, ns("snap_button"))
       })
 
@@ -71,7 +71,7 @@ snapPointServer <- function(id, input_point_table) {
       snapped_data <- reactiveValues(data = NULL)
 
       # If click snap button, snap points, otherwise do nothing
-        observeEvent(input$snap_button, once = TRUE, {
+        observeEvent(input$snap_button, {
 
         # stop if a table with input points does not exist
         req(input_point_table())
@@ -191,8 +191,17 @@ snapPointServer <- function(id, input_point_table) {
         # hide processing text
         shinyjs::hide("text1")
 
+        # reset progress bar
+        custom_updateProgressBar(perc = 0, sleep = 0.8)
+
+        # show tooltip again
+        addTooltip(session,
+                   ns("snap_button"),
+                   "Please, upload point data first",
+                   placement = "right")
+
         # enable snap button
-        shinyjs::enable("snap_button")
+        #shinyjs::enable("snap_button")
       })
 
       # Option 2: snap point to nearest stream segment

--- a/R/mod_snap_points.R
+++ b/R/mod_snap_points.R
@@ -19,7 +19,7 @@ snapPointUI <- function(id, label = "Snap points") {
     # Tooltip to indicate point data must be uploaded before snapping.
     # It is hidden after point data is uploaded
     bsTooltip(ns("snap_button"),
-              "Please, upload point data first",
+              "Please, upload your data first or load test data",
               "right",
               options = list(container = "body")
     ),

--- a/R/mod_snap_points.R
+++ b/R/mod_snap_points.R
@@ -9,24 +9,29 @@ snapPointUI <- function(id, label = "Snap points") {
     tags$b("Snapping method: sub-catchment (default)"),
     p("Points will be snapped to the nearest location on the
               river segment of the sub-catchment the point falls in."),
+    # Inactive action button. It is activated after data point is uploaded.
+    # Point snapping starts after clicking
     shinyjs::disabled(actionButton(ns("snap_button"),
                  label = "Snap points",
                  icon = icon("arrow-right"),
                  class = "btn-primary"
-    ))
-    ,
+    )),
+    # Tooltip to indicate point data must be uploaded before snapping.
+    # It is hidden after point data is uploaded
+    bsTooltip(ns("snap_button"),
+              "Please, upload point data first",
+              "right",
+              options = list(container = "body")
+    ),
     br(),
+    # Progress bar, indicates the progress of snapping process
     progressBar(
       id = ns("progress_snap"),
       value = 0,
       title = " ",
       display_pct = TRUE
     ),
-    bsTooltip(ns("snap_button"),
-              "Please, upload point data first",
-              "right",
-              options = list(container = "body")
-    ),
+    # Text indicating snapping is taking place
     shinyjs::hidden(p(id = ns("text1"), "Processing..."))
   )
 }
@@ -52,9 +57,11 @@ snapPointServer <- function(id, input_point_table) {
         Sys.sleep(0.1)
       }
 
-      # activate snap button after a table with the user's points is loaded
+      # activate snap button and hide tooltip after a table with the user's
+      # points is loaded
       observeEvent(input_point_table(), {
         toggleState("snap_button")
+        removeTooltip(session, ns("snap_button"))
       })
 
       # reactive value object. Its value change after snapping is completed

--- a/R/mod_upload_csv.R
+++ b/R/mod_upload_csv.R
@@ -10,8 +10,10 @@ csvFileUI <- function(id, label = "CSV file") {
   sidebarLayout(
     sidebarPanel(
       # Upload a CSV file with three columns:
-      # point id, longitude, latitude
-      fileInput(ns("file"), label = "Point data (.csv format)", accept = ".csv"),
+      # point id, longitude, latitude.
+      # Using uiOutput instead of fileInput to be able to reset form
+      # when test data set is uploaded.
+      uiOutput(ns("file")),
       # button for loading test data csv
       actionButton(
         ns("test_data"),
@@ -26,8 +28,8 @@ csvFileUI <- function(id, label = "CSV file") {
       # show the uploaded CSV as a table
       tableOutput(ns("csv_table")),
       uiOutput(ns("download_snapped"))
-      #hr(),
-      #downloadDataUI(ns("download"))
+      # hr(),
+      # downloadDataUI(ns("download"))
     )
   )
 }
@@ -39,6 +41,11 @@ csvFileServer <- function(id, map_proxy, stringsAsFactors) {
     id,
     function(input, output, session) {
       ns <- session$ns
+
+      # render file input
+      output$file <- renderUI({
+        fileInput(ns("file"), label = "Point data (.csv format)", accept = ".csv")
+      })
 
       # non-reactive data frame for displaying an empty table
       empty_df <- matrix(ncol = 3, nrow = 10) %>% as.data.frame()
@@ -111,6 +118,12 @@ csvFileServer <- function(id, map_proxy, stringsAsFactors) {
 
         # reset progress bar
         reset_progress_bar("panel3-datafile-snap-pb2")
+
+        # reset file input (only if a file was already uploaded)
+        req(input$file)
+        output$file <- renderUI({
+          fileInput(ns("file"), label = "Point data (.csv format)", accept = ".csv")
+        })
       })
 
       # The user's coordinates, parsed into a data frame

--- a/R/mod_upload_csv.R
+++ b/R/mod_upload_csv.R
@@ -26,6 +26,8 @@ csvFileUI <- function(id, label = "CSV file") {
       # show the uploaded CSV as a table
       tableOutput(ns("csv_table")),
       uiOutput(ns("download_snapped"))
+      #hr(),
+      #downloadDataUI(ns("download"))
     )
   )
 }
@@ -268,6 +270,17 @@ csvFileServer <- function(id, map_proxy, stringsAsFactors) {
           file_name = "-snapped-method-sub-catchment"
         )
       })
+
+      # If a new point dataset is uploaded or the test data is loaded don't show
+      # download button
+      observeEvent(coordinates_user(), {
+        output$download_snapped <- renderUI({
+          tagList(
+            hr()
+          )
+        })
+      })
+
 
       # Module output. A list with three reactive expressions:
       # - data frame with user's coordinates uploaded from CSV


### PR DESCRIPTION
- Snap button disable after snapping. It is enabled whenever a new point dataset is loaded
- Snapping progress bar reset after snapping
- Tooltips on snap button and query button when disable. These tooltips indicates that and action must be done first in order to enable these buttons
- download button visible after snapping. If a new dataset is loaded after snapping, download button is hidden 